### PR TITLE
Update diff.go

### DIFF
--- a/diff/diff.go
+++ b/diff/diff.go
@@ -12,10 +12,10 @@ type FileDiff struct {
 	// the old path of the file
 	PathOld string
 	// the new path of the file
-	PathNew string
+	Pathnew string
 
 	// the old timestamp (empty if not present)
-	TimeOld string
+	Timeold string
 	// the new timestamp (empty if not present)
 	TimeNew string
 


### PR DESCRIPTION
- [ ] Updated Unreleased section in [CHANGELOG](https://github.com/reviewdog/reviewdog/blob/master/CHANGELOG.md) or it's not notable changes.

This pull request includes a few changes to the `FileDiff` struct in the `diff/diff.go` file to standardize the naming conventions. The most important changes include renaming `PathNew` to `Pathnew` and `TimeOld` to `Timeold`.

Changes to `FileDiff` struct:

* Renamed `PathNew` to `Pathnew` to standardize naming conventions.
* Renamed `TimeOld` to `Timeold` to standardize naming conventions.